### PR TITLE
Add argmax sampling option

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ The implemented decoding methods are as follows:
   - Classifier-based guidance (D-CBG); set `guidance=cbg`
   - Classifier-based (baseline) method of [NOS](https://arxiv.org/abs/2305.20009); set `guidance=nos`
 
+When evaluating models, Gumbel sampling is used by default. Set `eval.argmax_sampling: True` in the config to select tokens deterministically with `argmax` instead.
+
 ### Implemented Generative Models
 <a name="implemented-models"></a>
 The three modeling parameterizations

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -69,6 +69,7 @@ eval:
   max_samples: 50_000
   low_confidence_sampling: False  # Run low-probability sampling during eval
   low_confidence_threshold: 0.3   # Fraction of cumulative mass for low-conf sampling
+  argmax_sampling: False  # Use argmax instead of Gumbel sampling during eval
 
 optim:
   weight_decay: 0

--- a/diffusion.py
+++ b/diffusion.py
@@ -1745,6 +1745,10 @@ class Diffusion(L.LightningModule):
         mask.scatter_(dim=-1, index=sorted_idx, src=mask_sorted)
         probs = probs.masked_fill(~mask, 0.0)
 
+    if (hasattr(self.config, 'eval') and
+        getattr(self.config.eval, 'argmax_sampling', False)):
+        return probs.argmax(dim=-1)
+
     gumbel_norm = (
       1e-10
       - (torch.rand_like(probs) + 1e-10).log()).to(probs.dtype)


### PR DESCRIPTION
## Summary
- support deterministic sampling using eval.argmax_sampling
- mention argmax sampling flag in README

## Testing
- `python -m py_compile diffusion.py`

------
https://chatgpt.com/codex/tasks/task_e_684ef82499b0832fa6577314d4cc3cd8